### PR TITLE
Adds basic support to css modules

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import { Header } from '../Header'
 import { getTime } from '../../lib/getTime'
-import './style.css'
+import * as style from './style.css'
 
 // The second paramenter of the extended class is the state object ('undefined' in this case)
 export class App extends React.Component<React.Props<any>, undefined> {
   public render() {
     return (
-      <div className="App">
+      <div className={style.App}>
         <Header/>
         <img src="assets/images/ts-react.png"/>
         <p>It's around {getTime()} and everything is fine.</p>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import './style.css'
+import * as style from './style.css'
 
 // React.SFC is a shorthand for React.StatelessComponent (plus the F of Functional)
 export const Header:React.SFC<React.Props<any>> = () => (
-  <h1 className="Header">React with TypeScript: a starter kit</h1>
+  <h1 className={style.Header}>React with TypeScript: a starter kit</h1>
 )

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+  const classes: {[className: string]: string};
+  export = classes;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,7 +71,9 @@ const webpackConfig = {
           {
             loader: require.resolve('css-loader'),
             options: {
-              importLoaders: 1
+              importLoaders: 1,
+              modules: true,
+              localIdentName: '[name]__[local]___[hash:base64:5]'
             }
           },
           {


### PR DESCRIPTION
This PR (not to be merged, at the moment) adds basic support for [CSS modules](https://github.com/css-modules/css-modules) to the project. It does it by:

- enabling the native "modules" option in webpack css loader
- changing the JSX templates to use the `style.dynamicallyGeneratedClassName` style for className property in React
- adds a catch-all `global.d.ts` for TypeScript to be able to "see" the styles.css module files (only for TS 2.0+) (thanks to @mohsen1 for the idea)

What is missing is a proper loader which would create the `d.ts` file for each css module on the fly, so to be able for the editor to provide autocomplete feature and avoid using a global.d.ts. 

There are two or three options to do that (plus the changes in the WebPack configuration to deal with the dynamic generation of new files in the `src` directory), [see this issue](https://github.com/Quramy/typed-css-modules/issues/2) for a deeper discussion on the topic. As for the project goal, I try to avoid taking decisions on behalf of who is going to use starter kit for a serious project when they can have an impact on the final result.